### PR TITLE
Stop using deleted SessionAuthenticationMiddleware

### DIFF
--- a/server/src/dixit/settings.py
+++ b/server/src/dixit/settings.py
@@ -61,7 +61,6 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]


### PR DESCRIPTION
SessionAuthenticationMiddleware was removed in Django 2. This middleware
should not be used anymore.

https://docs.djangoproject.com/en/3.0/releases/2.0/

Signed-off-by: Remy Suen <remy.suen@gmail.com>